### PR TITLE
Reinstate 1-13 changes to existing team pages

### DIFF
--- a/team/_posts/1970-01-01-almasri-ab.md
+++ b/team/_posts/1970-01-01-almasri-ab.md
@@ -11,6 +11,8 @@ twitter:
 scholar: 
 image: /assets/images/team/almasri-ab.png
 cv:
+alum: true
+parting_date: 2024-08-31
 ---
 
 A Computer-Science student with software engineering aspirations, A.b became a Broadie in summer of 2024 joining the Getz lab as a full-stack engineering intern. A.b worked side by side with the talented software engineering team on the Portal Project implementing features such as the "Analytical Statistics Dashboard" and others. 

--- a/team/_posts/1970-01-01-belkin-saveliy.md
+++ b/team/_posts/1970-01-01-belkin-saveliy.md
@@ -1,6 +1,7 @@
 ---
 layout: member
 title: Saveliy Belkin
+citation_names: Belkin S
 category: Staff Engineer
 position: Senior Software Engineer
 email: sbelkin@broadinstitute.org

--- a/team/_posts/1970-01-01-garay-diego.md
+++ b/team/_posts/1970-01-01-garay-diego.md
@@ -11,6 +11,8 @@ twitter:
 scholar: 
 image: /assets/images/team/garay-diego.png
 cv:
+alum: true
+parting_date: 2024-08-31
 ---
 
 Diego joined the Getz lab in the summer of 2024 as a summer intern. He is a sophomore at Amherst College studying mathematics. He is currently working on the project portal, such as adding the ability to analyze sequenced data using wolF through the portal. 

--- a/team/_posts/1970-01-01-lipieta_natalie.md
+++ b/team/_posts/1970-01-01-lipieta_natalie.md
@@ -9,6 +9,8 @@ github: nlipieta
 linkedin: 
 image: /assets/images/team/natalie_lipieta.png
 cv:
+alum: true
+parting_date: 2024-08-31
 ---
 
 Natalie is currently a senior in high school. She joined the lab in February of 2023. She is interested in applying bioinformatics techniques to make breakthroughs in the field of cancer biology. In the future, she plans to attend college, studying genetics and epigenetics. Outside of research, she enjoys listening to music, SCUBA diving, and watching scary movies.

--- a/team/_posts/1970-01-01-lopez-sara.md
+++ b/team/_posts/1970-01-01-lopez-sara.md
@@ -11,6 +11,8 @@ github: saraltamargo
 linkedin: sara-lópez-tamargo-a1b37b160
 image: /assets/images/team/sara_lopez.jpg
 cv:
+alum: true
+parting_date: 2024-11-31
 ---
 
 Sara is a fifth-year PhD student in Genomic and Molecular Approaches to Biomedicine at the University of Oviedo, under the supervision of Dr. Xosé Antón Suárez Puente. Her research focuses on understanding how splicing deregulation affects hematological tumors, with a particular emphasis on how these changes reshape the tumor microenvironment. To achieve this, Sara employs various NGS technologies and quantitative methods to analyze both experimental animal models and clinical data, with a special focus on single-cell technologies.

--- a/team/_posts/1970-01-01-maus-nick.md
+++ b/team/_posts/1970-01-01-maus-nick.md
@@ -11,6 +11,8 @@ twitter:
 scholar: 
 image: /assets/images/team/maus_nick.png
 cv:
+alum: true
+parting_date: 2024-08-31
 ---
 
 Nick joined the Getz Lab in June of 2024 as a summer intern, and is currently working on analyzing single cell RNA sequencing data, particularly comparing different analysis methods. He is a rising Senior at Carnegie Mellon University where he is double majoring in Mathematics and Computer Science.

--- a/team/_posts/1970-01-01-pospistle-amber.md
+++ b/team/_posts/1970-01-01-pospistle-amber.md
@@ -9,6 +9,8 @@ github:
 linkedin: amber-pospistle
 image: /assets/images/team/amber_pospistle.jpg
 cv:
+alum: true
+parting_date: 2024-08-31
 ---
 
 Amber is a senior Computational Biology major at the University of South Carolina where she is a Goldwater and Stamps Scholar. She joined the Getz Lab in the summer of 2023. Previously, her research in the Getz Lab involved a method to distinguish between somatic and germline mutations using tumor-only samples. She is currently researching follicular lymphoma. In the future, she plans to attain a Ph.D. in Computational Biology and pursue a research career applying computational biology tools to study immuno-oncology and neurological disorders. Outside of research, she enjoys painting, poetry, and listening to music.

--- a/team/_posts/1970-01-01-stuart-james.md
+++ b/team/_posts/1970-01-01-stuart-james.md
@@ -11,6 +11,8 @@ twitter:
 scholar: 
 image: /assets/images/team/stuart-james.png
 cv:
+alum: true
+parting_date: 2024-08-31
 ---
 
 James is a rising senior at Skidmore College studying Neuroscience. He joined the lab as a summer intern and is working on analyzing whole genome data using computational tools developed in the lab. James has previous experience in cancer research. Last summer, he worked at a startup in small molecule drug discovery where he performed wet lab procedures such as tissue culture and various cellular assays. After completing his undergraduate degree, James plans to pursue an MD-PhD in neuroscience. 

--- a/team/_posts/1970-01-01-wenckstern-johann.md
+++ b/team/_posts/1970-01-01-wenckstern-johann.md
@@ -11,6 +11,8 @@ github: johannwenckstern
 linkedin: johannw
 image: /assets/images/team/johann_wenckstern.jpg
 cv:
+alum: true
+parting_date: 2024-10-31
 ---
 
 Johann is a visiting graduate student in the Getz Lab, where he is working on machine learning algorithms to learn patient representations from single-cell RNA sequencing data. He recently completed his master's in mathematics at ETH Zurich and is set to begin his PhD in computer science at EPFL, where he aspires to develop methods to advance personalized medicine through the use of genomics data and machine learning.

--- a/team/_posts/1970-01-01-wiseman-sam.md
+++ b/team/_posts/1970-01-01-wiseman-sam.md
@@ -1,6 +1,7 @@
 ---
 layout: member
 title: Sam Wiseman
+citation_names: Wiseman S
 category: Staff Engineer
 position: Senior Software Engineer
 email: swiseman@broadinstitute.org


### PR DESCRIPTION
Seeing if site building will break again if we only add the citation_names / alum / parting_date fields of existing pages